### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/support": "^5.5"
+        "illuminate/support": "5.5.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10"


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.