### PR TITLE
(doc): fix typo and make writing more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 
-Small package that'll generate the integrity hashes for your style and script file.
+Small package that'll generate the integrity hashes for your style and script files.
 
 ## Installation
 
@@ -10,7 +10,7 @@ Small package that'll generate the integrity hashes for your style and script fi
 $ composer require elhebert/laravel-sri
 ```
 
-This package use auto-discovery, so you don't have to do anything. It works out of the box.
+This package uses [auto-discovery](https://laravel.com/docs/5.5/packages#package-discovery), so you don't have to do anything. It works out of the box.
 
 ## Config
 
@@ -24,7 +24,7 @@ $ php artisan vendor:publish --provider="Elhebert\SubresourceIntegrity\SriServic
 
 ## Usage
 
-To only get a hash use `Sri::hash`
+To only get a hash, use `Sri::hash`:
 
 ```html
 <link
@@ -45,7 +45,9 @@ Or you can use `Sri::html` to generate the integrity and the crossorigin attribu
 >
 ```
 
-This package also work for remote resources. Be careful that resources like Google Fonts [won't work](https://github.com/google/fonts/issues/473).
+## Remote resources
+
+This package also works for remote resources. Be careful that resources like Google Fonts [won't work](https://github.com/google/fonts/issues/473).
 
 ```html
 <script
@@ -60,4 +62,4 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for more details.
 
 ## License
 
-This project and The Laravel framework are open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).
+This project and the Laravel framework are open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
A suggestion to make the README more handy: clear some grammatical errors, and a bit of punctuation, a link and a title.