### PR TITLE
Add quotes around HTML

### DIFF
--- a/src/Sri.php
+++ b/src/Sri.php
@@ -26,7 +26,7 @@ class Sri
 
         $crossOrigin = $useCredentials ? 'use-credentials' : 'anonymous';
 
-        return "integrity={$integrity} crossorigin={$crossOrigin}";
+        return "integrity='{$integrity}' crossorigin='{$crossOrigin}'";
     }
 
     public function hash(string $path): string

--- a/tests/GenerateSriHtmlTest.php
+++ b/tests/GenerateSriHtmlTest.php
@@ -22,7 +22,7 @@ class GenerateSriHtmlTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertContains("integrity=sha256-{$base64Hash}", Sri::html('files/app.css'));
+        $this->assertContains("integrity='sha256-{$base64Hash}'", Sri::html('files/app.css'));
     }
 
     /** @test */
@@ -35,7 +35,7 @@ class GenerateSriHtmlTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertContains("integrity=sha256-{$base64Hash}", Sri::html('files/app.css', true));
-        $this->assertContains('crossorigin=use-credentials', Sri::html('files/app.css', true));
+        $this->assertContains("integrity='sha256-{$base64Hash}'", Sri::html('files/app.css', true));
+        $this->assertContains("crossorigin='use-credentials'", Sri::html('files/app.css', true));
     }
 }


### PR DESCRIPTION
Although HTML is completely valid without quotes around the values (as long as the value doesn't contain spaces) it seems that Firefox doesn't seem to like the lack of quotes because it can contain an `=` character (from the base64 encoding). 🤔

![Example image](https://image.prntscr.com/image/yle09102S6qzyWExEw9V0A.png)