### PR TITLE
Fix PHPUnit configuration logging attributes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>


### PR DESCRIPTION
Since PHPUnit 7, the `charset`, `yui` and `highlight` attributes have
been deprecated in the `log` element for PHPUnit schema validation.