### PR TITLE
Move directive initialisation to the boot method

### DIFF
--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -19,6 +19,13 @@ class SriServiceProvider extends ServiceProvider
             __DIR__.'/../config/subresource-integrity.php',
             'subresource-integrity'
         );
+    }
+
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__.'/../config/subresource-integrity.php' => config_path('subresource-integrity.php'),
+        ]);
 
         Blade::directive('mixSri', function (string $path, bool $crossOrigin = false) {
             if (starts_with($path, ['http', 'https', '//'])) {
@@ -55,12 +62,5 @@ class SriServiceProvider extends ServiceProvider
                 throw new \Exception('Invalid file');
             }
         });
-    }
-
-    public function boot()
-    {
-        $this->publishes([
-            __DIR__.'/../config/subresource-integrity.php' => config_path('subresource-integrity.php'),
-        ]);
     }
 }


### PR DESCRIPTION
As per the conversation in #23 it seems that the `Blade::directive()` usage in the `register()` method isn't initialised. In Laravel 5.8, the `facadeAccessor()` for the `Blade` facade now returns the accessor string instead of an instance like in previous versions (see laravel/framework#25497).

According to the documentation, using facades in the `register` method isn't recommended as they may not have been defined yet, so they should be used in the `boot` method, which occurs after all `register` methods have finished.

I've tested this in Laravel 5.5, 5.6 and 5.8. Also, @HDVinnie has tested it on dev servers using Laravel 5.7 and 5.8 as per https://github.com/Elhebert/laravel-sri/issues/23#issuecomment-469925311.

The PHPUnit tests seem to work as expected on Travis and locally, but @Elhebert, please feel free to test this.

Fixes #23