### PR TITLE
Fix default `mix_sri_path`

### DIFF
--- a/config/subresource-integrity.php
+++ b/config/subresource-integrity.php
@@ -5,7 +5,7 @@ return [
 
     'algorithm' => env('SRI_ALGORITHM', 'sha256'),
 
-    'mix_sri_path' => public_path('mix_sri.json'),
+    'mix_sri_path' => public_path('mix-sri.json'),
 
     'hashes' => [
         //


### PR DESCRIPTION
Fixes the default `mix_sri_path`, which uses a dash, not underscore.