### PR TITLE
Add method for parse path on directives

### DIFF
--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Elhebert\SubresourceIntegrity;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
@@ -29,39 +30,88 @@ class SriServiceProvider extends ServiceProvider
         ]);
 
         Blade::directive('mixSri', function (string $path, bool $crossOrigin = false) {
+            $path = $this->clean_path($path);
+
             if (Str::startsWith($path, ['http', 'https', '//'])) {
                 $href = $path;
             } else {
                 $href = mix($path);
             }
 
-            $integrity = SriFacade::html($path, $crossOrigin);
-
-            if (Str::endsWith($path, 'css')) {
-                return "<link href='{$href}' rel='stylesheet' {$integrity}>";
-            } elseif (Str::endsWith($path, 'js')) {
-                return "<script src='{$href}' {$integrity}></script>";
-            } else {
-                throw new \Exception('Invalid file');
-            }
+            return $this->generate($path, $href, $crossOrigin);
         });
 
         Blade::directive('assetSri', function (string $path, bool $crossOrigin = false) {
+            $path = $this->clean_path($path);
+
             if (Str::startsWith($path, ['http', 'https', '//'])) {
                 $href = $path;
             } else {
                 $href = asset($path);
             }
 
-            $integrity = SriFacade::html($path, $crossOrigin);
-
-            if (Str::endsWith($path, 'css')) {
-                return "<link href='{$href}' rel='stylesheet' {$integrity}>";
-            } elseif (Str::endsWith($path, 'js')) {
-                return "<script src='{$href}' {$integrity}></script>";
-            } else {
-                throw new \Exception('Invalid file');
-            }
+            return $this->generate($path, $href, $crossOrigin);
         });
+    }
+
+    /**
+     * Remove apostrophe and quotation mark.
+     * 
+     * @param string  $path
+     * @return string
+     * 
+     * @throws \Exception
+     */
+    private function clean_path($path): string
+    {
+        $values = ['\'', '"'];
+        return str_replace($values, '', $path);
+    }
+
+    /**
+     * Parse and generate the URL.
+     * 
+     * @param string  $path
+     * @param string  $href
+     * @param bool    $crossOrigin
+     * @return void
+     * 
+     * @throws \Exception
+     */
+    private function generate(string $path, string $href, bool $crossOrigin)
+    {
+        $integrity = SriFacade::html($href, $crossOrigin);
+
+        if (Str::endsWith($path, 'css')) {
+            return $this->css($href, $integrity);
+        } elseif (Str::endsWith($path, 'js')) {
+            return $this->js($href, $integrity);
+        } else {
+            throw new \Exception('Invalid file');
+        }
+    }
+
+    /**
+     * Generate JS URL.
+     * 
+     * @param string $href
+     * @param string $integrity
+     * @return \Illuminate\Support\HtmlString string
+     */
+    private function js(string $href, string $integrity)
+    {
+        return new HtmlString("<script src='".$href."' ".$integrity."></script>");
+    }
+
+    /**
+     * Generate CSS URL.
+     * 
+     * @param string $href
+     * @param string $integrity
+     * @return \Illuminate\Support\HtmlString string
+     */
+    private function css(string $href, string $integrity)
+    {
+        return new HtmlString("<link href='".$href."' rel='stylesheet' ".$integrity.">");
     }
 }

--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -61,7 +61,7 @@ class SriServiceProvider extends ServiceProvider
         return str_replace($values, '', $path);
     }
 
-    private function parseAndGenerateUrl(string $path, string $href, bool $crossOrigin)
+    private function parseAndGenerateUrl(string $path, string $href, bool $crossOrigin): HtmlString
     {
         $integrity = SriFacade::html($href, $crossOrigin);
 

--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -65,6 +65,7 @@ class SriServiceProvider extends ServiceProvider
     private function clean_path($path): string
     {
         $values = ['\'', '"'];
+        
         return str_replace($values, '', $path);
     }
 

--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -56,10 +56,10 @@ class SriServiceProvider extends ServiceProvider
 
     /**
      * Remove apostrophe and quotation mark.
-     * 
+     *
      * @param string  $path
      * @return string
-     * 
+     *
      * @throws \Exception
      */
     private function clean_path($path): string
@@ -70,12 +70,12 @@ class SriServiceProvider extends ServiceProvider
 
     /**
      * Parse and generate the URL.
-     * 
+     *
      * @param string  $path
      * @param string  $href
      * @param bool    $crossOrigin
      * @return void
-     * 
+     *
      * @throws \Exception
      */
     private function generate(string $path, string $href, bool $crossOrigin)
@@ -93,25 +93,25 @@ class SriServiceProvider extends ServiceProvider
 
     /**
      * Generate JS URL.
-     * 
+     *
      * @param string $href
      * @param string $integrity
      * @return \Illuminate\Support\HtmlString string
      */
     private function js(string $href, string $integrity)
     {
-        return new HtmlString("<script src='".$href."' ".$integrity."></script>");
+        return new HtmlString("<script src='{$href}' {$integrity}></script>");
     }
 
     /**
      * Generate CSS URL.
-     * 
+     *
      * @param string $href
      * @param string $integrity
      * @return \Illuminate\Support\HtmlString string
      */
     private function css(string $href, string $integrity)
     {
-        return new HtmlString("<link href='".$href."' rel='stylesheet' ".$integrity.">");
+        return new HtmlString("<link href='{$href}' rel='stylesheet' {$integrity}>");
     }
 }

--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -65,7 +65,7 @@ class SriServiceProvider extends ServiceProvider
     private function clean_path($path): string
     {
         $values = ['\'', '"'];
-        
+
         return str_replace($values, '', $path);
     }
 


### PR DESCRIPTION
Actually, when use Blade directives, you can be make `@assetSRI(/css/app.css)`, with this PR, you too can be make `@assetSRI("/css/app.css")` or `@assetSri('/css/app.css')`.

It work's with `@mixSri` too.

Based on #16.