### PR TITLE
Fix code pattern in HTML tags (v2)

### DIFF
--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -76,11 +76,11 @@ class SriServiceProvider extends ServiceProvider
 
     private function generateJsUrl(string $href, string $integrity): HtmlString
     {
-        return new HtmlString("<script src='{$href}' {$integrity}></script>");
+        return new HtmlString('<script src="{$href}" {$integrity}></script>');
     }
 
     private function generateCssUrl(string $href, string $integrity): HtmlString
     {
-        return new HtmlString("<link href='{$href}' rel='stylesheet' {$integrity}>");
+        return new HtmlString('<link href="{$href}" rel="stylesheet" {$integrity}>');
     }
 }


### PR DESCRIPTION
In default Blade template, it's using double quotes.

This PR, change this, to fix code pattern in generated HTML tags.

Currently:
`<script src='/js/app.js' integrity='sha256-...=' crossorigin='anonymous'></script>`
Now:
`<script src="/js/app.js" integrity="sha256-...=' crossorigin="anonymous"></script>`