### PR TITLE
Using array_key_exists() on objects is deprecated in PHP 7.4

### DIFF
--- a/src/Sri.php
+++ b/src/Sri.php
@@ -39,7 +39,7 @@ class Sri
             $json = json_decode(file_get_contents($this->jsonFilePath()));
             $prefixedPath = Str::startsWith($path, '/') ? $path : "/{$path}";
 
-            if (array_key_exists($prefixedPath, $json)) {
+            if (property_exists($json, $prefixedPath)) {
                 return $json->$prefixedPath;
             }
         }


### PR DESCRIPTION
See https://www.php.net/manual/en/migration74.deprecated.php