### PR TITLE
Fixed get integrity when using mix version()

### DIFF
--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -63,7 +63,7 @@ class SriServiceProvider extends ServiceProvider
 
     private function parseAndGenerateUrl(string $path, string $href, bool $crossOrigin): HtmlString
     {
-        $integrity = SriFacade::html($href, $crossOrigin);
+        $integrity = SriFacade::html($path, $crossOrigin);
 
         if (Str::endsWith($path, 'css')) {
             return $this->generateCssUrl($href, $integrity);


### PR DESCRIPTION
It seems that PR #30 accidentally passed `$html` to get the integrity value but this causes if you are using mix `version()` and `mix-sri.json` that the property will not be found and it will always recalculate the SRI value on each load.

This PR should fix this issue.