### PR TITLE
Fix generate html facade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
-        "illuminate/support": "^6.0 | ^7.0",
+        "illuminate/support": "^6.0 | ^7.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0 | ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "illuminate/support": "^6.0 | ^7.0"
+        "ext-json": "*",
+        "illuminate/support": "^6.0 | ^7.0",
     },
     "require-dev": {
         "orchestra/testbench": "^4.0 | ^5.0",

--- a/src/Sri.php
+++ b/src/Sri.php
@@ -46,7 +46,7 @@ class Sri
         }
 
         if ($this->mixFileExists()) {
-            $json = json_decode(file_get_contents($this->jsonFilePath()));
+            $json         = json_decode(file_get_contents($this->jsonFilePath()));
             $prefixedPath = Str::startsWith($path, '/') ? $path : "/{$path}";
 
             if (property_exists($json, $prefixedPath)) {
@@ -54,7 +54,7 @@ class Sri
             }
         }
 
-        $hash = hash($this->algorithm, $this->getFileContent($path), true);
+        $hash       = hash($this->algorithm, $this->getFileContent($path), true);
         $base64Hash = base64_encode($hash);
 
         return "{$this->algorithm}-{$base64Hash}";
@@ -79,7 +79,7 @@ class Sri
                 $path = Str::startsWith($path, '/') ? $path : "/{$path}";
                 $path = parse_url($path, PHP_URL_PATH);
 
-                $fileContent = file_get_contents(config('subresource-integrity.base_path')."{$path}");
+                $fileContent = file_get_contents(config('subresource-integrity.base_path') . "{$path}");
             }
 
             if (! $fileContent) {

--- a/src/Sri.php
+++ b/src/Sri.php
@@ -3,6 +3,7 @@
 namespace Elhebert\SubresourceIntegrity;
 
 use Exception;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
 class Sri
@@ -17,21 +18,21 @@ class Sri
             : 'sha256';
     }
 
-    public function html(string $path, bool $useCredentials = false): string
+    public function html(string $path, bool $useCredentials = false): HtmlString
     {
         if (! config('subresource-integrity.enabled')) {
-            return '';
+            return new HtmlString('');
         }
 
         try {
             $integrity = $this->hash($path);
         } catch (\Exception $e) {
-            return '';
+            return new HtmlString('');
         }
 
         $crossOrigin = $useCredentials ? 'use-credentials' : 'anonymous';
 
-        return "integrity='{$integrity}' crossorigin='{$crossOrigin}'";
+        return new HtmlString("integrity=\"{$integrity}\" crossorigin=\"{$crossOrigin}\"");
     }
 
     public function hash(string $path): string

--- a/src/Sri.php
+++ b/src/Sri.php
@@ -32,7 +32,7 @@ class Sri
 
         $crossOrigin = $useCredentials ? 'use-credentials' : 'anonymous';
 
-        return new HtmlString("integrity=\"{$integrity}\" crossorigin=\"{$crossOrigin}\"");
+        return new HtmlString('integrity="' . $integrity . '" crossorigin="' . $crossOrigin . '"');
     }
 
     public function hash(string $path): string

--- a/tests/GenerateSriHtmlTest.php
+++ b/tests/GenerateSriHtmlTest.php
@@ -18,7 +18,7 @@ class GenerateSriHtmlTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertStringContainsString("integrity=\"sha256-{$base64Hash}\"", Sri::html('files/app.css'));
+        $this->assertStringContainsString('integrity="sha256-' . $base64Hash . '"', Sri::html('files/app.css'));
     }
 
     /** @test */

--- a/tests/GenerateSriHtmlTest.php
+++ b/tests/GenerateSriHtmlTest.php
@@ -18,7 +18,7 @@ class GenerateSriHtmlTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", Sri::html('files/app.css'));
+        $this->assertStringContainsString("integrity=\"sha256-{$base64Hash}\"", Sri::html('files/app.css'));
     }
 
     /** @test */
@@ -27,8 +27,8 @@ class GenerateSriHtmlTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", Sri::html('files/app.css', true));
-        $this->assertStringContainsString("crossorigin='use-credentials'", Sri::html('files/app.css', true));
+        $this->assertStringContainsString("integrity=\"sha256-{$base64Hash}\"", Sri::html('files/app.css', true));
+        $this->assertStringContainsString("crossorigin=\"use-credentials\"", Sri::html('files/app.css', true));
     }
 
     /** @test */

--- a/tests/GenerateSriHtmlTest.php
+++ b/tests/GenerateSriHtmlTest.php
@@ -27,8 +27,8 @@ class GenerateSriHtmlTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertStringContainsString("integrity=\"sha256-{$base64Hash}\"", Sri::html('files/app.css', true));
-        $this->assertStringContainsString("crossorigin=\"use-credentials\"", Sri::html('files/app.css', true));
+        $this->assertStringContainsString('integrity="sha256-' . $base64Hash . '", Sri::html('files/app.css', true));
+        $this->assertStringContainsString('crossorigin="use-credentials"', Sri::html('files/app.css', true));
     }
 
     /** @test */

--- a/tests/GenerateSriHtmlTest.php
+++ b/tests/GenerateSriHtmlTest.php
@@ -15,7 +15,7 @@ class GenerateSriHtmlTest extends TestCase
     /** @test */
     public function it_generates_html_code_with_integrity()
     {
-        $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
+        $hash       = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
         $this->assertStringContainsString('integrity="sha256-' . $base64Hash . '"', Sri::html('files/app.css'));
@@ -24,10 +24,10 @@ class GenerateSriHtmlTest extends TestCase
     /** @test */
     public function it_generate_html_code_with_credentials_and_integrity()
     {
-        $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
+        $hash       = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertStringContainsString('integrity="sha256-' . $base64Hash . '", Sri::html('files/app.css', true));
+        $this->assertStringContainsString('integrity="sha256-' . $base64Hash . '"', Sri::html('files/app.css', true));
         $this->assertStringContainsString('crossorigin="use-credentials"', Sri::html('files/app.css', true));
     }
 
@@ -38,7 +38,7 @@ class GenerateSriHtmlTest extends TestCase
             'subresource-integrity.enabled' => false,
         ]);
 
-        $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
+        $hash       = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
         $this->assertEquals('', Sri::html('files/app.css', true));


### PR DESCRIPTION
When run `Sri::html` the html quote escaped.

Source:
`<link href="{{ asset('css/app.css') }}" rel="stylesheet" {{ Sri::html('css/app.css') }}>`


Expected result:
`<link href="/css/app.css" rel="stylesheet" integrity="sha256-ijZ6X3DXEILXpaiHcciFfBfpVZRwneRJ9MXfc9iuCF8=" crossorigin="anonymous">`

Actual result:
`<link href="/css/app.css" rel="stylesheet" integrity=&#039;sha256-ijZ6X3DXEILXpaiHcciFfBfpVZRwneRJ9MXfc9iuCF8=&#039; crossorigin=&#039;anonymous&#039;>`