### PR TITLE
Feature/add attributes to blade directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Two blade directive are available to make your views cleaner:
 Use `@mixSri` to generate the `<link>` or `<script>` tag with the proper attributes and using the `mix()` helper to generate the asset path:
 
 ```php
-@mixSri(string $path, bool $useCredentials = 'false')
+@mixSri(string $path, bool $useCredentials = 'false', string $attributes = '')
 ```
 
 Use `@assetSri` to generate the `<link>` or `<script>` tag with the proper attributes and using the `asset()` helper to generate the asset path:
 
 ```php
-@assetSri(string $path, bool $useCredentials = 'false')
+@assetSri(string $path, bool $useCredentials = 'false', string $attributes = '')
 ```
 
 ## How to get a hash

--- a/src/Sri.php
+++ b/src/Sri.php
@@ -60,6 +60,41 @@ class Sri
         return "{$this->algorithm}-{$base64Hash}";
     }
 
+    public function mix(string $path, bool $useCredentials = false, string $attributes = ''): string
+    {
+        if (Str::startsWith($path, ['http', 'https', '//'])) {
+            $href = $path;
+        } else {
+            $href = mix($path);
+        }
+
+        return $this->generateHtmlTag($href, $path, $useCredentials, $attributes);
+    }
+
+    public function asset(string $path, bool $useCredentials = false, string $attributes = ''): string
+    {
+        if (Str::startsWith($path, ['http', 'https', '//'])) {
+            $href = $path;
+        } else {
+            $href = asset($path);
+        }
+
+        return $this->generateHtmlTag($href, $path, $useCredentials, $attributes);
+    }
+
+    private function generateHtmlTag(string $href, string $path, bool $useCredentials, string $attributes): string
+    {
+        $integrity = $this->html($path, $useCredentials);
+
+        if (Str::endsWith($path, 'css')) {
+            return "<script src='{$href}' {$integrity} {$attributes}></script>";
+        } elseif (Str::endsWith($path, 'js')) {
+            return "<link href='{$href}' rel='stylesheet' {$integrity} {$attributes}>";
+        } else {
+            throw new \Exception('Invalid file');
+        }
+    }
+
     private function existsInConfigFile(string $path): bool
     {
         return array_key_exists($path, config('subresource-integrity.hashes'));

--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -3,9 +3,7 @@
 namespace Elhebert\SubresourceIntegrity;
 
 use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\HtmlString;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 
 class SriServiceProvider extends ServiceProvider
 {

--- a/src/SriServiceProvider.php
+++ b/src/SriServiceProvider.php
@@ -29,58 +29,12 @@ class SriServiceProvider extends ServiceProvider
             __DIR__.'/../config/subresource-integrity.php' => config_path('subresource-integrity.php'),
         ]);
 
-        Blade::directive('mixSri', function (string $path, bool $crossOrigin = false) {
-            $path = $this->removeQuotes($path);
-
-            if (Str::startsWith($path, ['http', 'https', '//'])) {
-                $href = $path;
-            } else {
-                $href = mix($path);
-            }
-
-            return $this->parseAndGenerateUrl($path, $href, $crossOrigin);
+        Blade::directive('mixSri', function ($arguments) {
+            return "<?php echo app('".Sri::class."')->mix({$arguments}) ?>";
         });
 
-        Blade::directive('assetSri', function (string $path, bool $crossOrigin = false) {
-            $path = $this->removeQuotes($path);
-
-            if (Str::startsWith($path, ['http', 'https', '//'])) {
-                $href = $path;
-            } else {
-                $href = asset($path);
-            }
-
-            return $this->parseAndGenerateUrl($path, $href, $crossOrigin);
+        Blade::directive('assetSri', function ($arguments) {
+            return "<?php echo app('".Sri::class."')->asset({$arguments}) ?>";
         });
-    }
-
-    private function removeQuotes(string $path): string
-    {
-        $values = ['\'', '"'];
-
-        return str_replace($values, '', $path);
-    }
-
-    private function parseAndGenerateUrl(string $path, string $href, bool $crossOrigin): HtmlString
-    {
-        $integrity = SriFacade::html($path, $crossOrigin);
-
-        if (Str::endsWith($path, 'css')) {
-            return $this->generateCssUrl($href, $integrity);
-        } elseif (Str::endsWith($path, 'js')) {
-            return $this->generateJsUrl($href, $integrity);
-        } else {
-            throw new \Exception('Invalid file');
-        }
-    }
-
-    private function generateJsUrl(string $href, string $integrity): HtmlString
-    {
-        return new HtmlString("<script src='{$href}' {$integrity}></script>");
-    }
-
-    private function generateCssUrl(string $href, string $integrity): HtmlString
-    {
-        return new HtmlString("<link href='{$href}' rel='stylesheet' {$integrity}>");
     }
 }

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -18,12 +18,11 @@ class BladeDirectiveTest extends TestCase
     {
         config([
             'subresource-integrity.mix_sri_path' => './tests/files/mix-sri.json',
-            'view.paths' => ['./tests/files'],
         ]);
 
         $this->app->instance('path.public', __DIR__.'/files');
 
-        $view = View::make('mixSri-view', [
+        $view = View::file(__DIR__.'/files/mixSri-view.blade.php', [
             'asset' => 'css/app.css',
             'useCredentials' => false,
             'attributes' => '',
@@ -37,14 +36,13 @@ class BladeDirectiveTest extends TestCase
     {
         config([
             'subresource-integrity.base_path' => './tests/files',
-            'view.paths' => ['./tests/files'],
             'app.asset_url' => 'tests/files',
         ]);
 
         $hash = hash('sha256', file_get_contents('./tests/files/app.js'), true);
         $base64Hash = base64_encode($hash);
 
-        $view = View::make('assetSri-view', [
+        $view = View::file(__DIR__.'/files/assetSri-view.blade.php', [
             'asset' => 'app.js',
             'useCredentials' => false,
             'attributes' => '',

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Elhebert\SubresourceIntegrity\Tests;
+
+use Illuminate\Support\Facades\View;
+
+class BladeDirectiveTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $this->artisan('view:clear');
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_renders_mixSri_directive()
+    {
+        config([
+            'subresource-integrity.mix_sri_path' => './tests/files/mix-sri.json',
+            'view.paths' => ['./tests/files'],
+        ]);
+
+        $this->app->instance('path.public', __DIR__.'/files');
+
+        $view = View::make('mixSri-view', [
+            'asset' => 'css/app.css',
+            'useCredentials' => false,
+            'attributes' => '',
+        ])->render();
+
+        $this->assertStringContainsString('this-hash-is-valid', $view);
+    }
+
+    /** @test */
+    public function it_renders_assetSri_directive()
+    {
+        config([
+            'subresource-integrity.base_path' => './tests/files',
+            'view.paths' => ['./tests/files'],
+            'app.asset_url' => 'tests/files',
+        ]);
+
+        $hash = hash('sha256', file_get_contents('./tests/files/app.js'), true);
+        $base64Hash = base64_encode($hash);
+
+        $view = View::make('assetSri-view', [
+            'asset' => 'app.js',
+            'useCredentials' => false,
+            'attributes' => '',
+        ])->render();
+
+        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $view);
+    }
+}

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -50,6 +50,6 @@ class BladeDirectiveTest extends TestCase
             'attributes' => '',
         ])->render();
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $view);
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $view);
     }
 }

--- a/tests/GenerateSriAssetTest.php
+++ b/tests/GenerateSriAssetTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Elhebert\SubresourceIntegrity\Tests;
+
+use Elhebert\SubresourceIntegrity\SriFacade as Sri;
+
+class GenerateSriAssetTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'subresource-integrity.base_path' => './tests/files',
+            'app.asset_url' => 'tests/files',
+        ]);
+    }
+
+    /** @test */
+    public function it_generates_css_with_integrity()
+    {
+        $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
+        $base64Hash = base64_encode($hash);
+
+        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", Sri::asset('app.css'));
+    }
+
+    /** @test */
+    public function it_generates_css_with_integrity_and_credentials()
+    {
+        $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
+        $base64Hash = base64_encode($hash);
+
+        $asset_string = Sri::asset('app.css', true);
+
+        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
+        $this->assertStringContainsString("crossorigin='use-credentials'", $asset_string);
+    }
+
+    /** @test */
+    public function it_generates_css_with_integrity_and_attributes()
+    {
+        $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
+        $base64Hash = base64_encode($hash);
+
+        $asset_string = Sri::asset('app.css', false, 'rel="stylesheet"');
+
+        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
+        $this->assertStringContainsString('rel="stylesheet"', $asset_string);
+    }
+
+    /** @test */
+    public function it_generates_css_with_integrity_credentials_and_attributes()
+    {
+        $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
+        $base64Hash = base64_encode($hash);
+
+        $asset_string = Sri::asset('app.css', true, 'rel="stylesheet"');
+
+        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
+        $this->assertStringContainsString("crossorigin='use-credentials'", $asset_string);
+        $this->assertStringContainsString('rel="stylesheet"', $asset_string);
+    }
+
+    /** @test */
+    public function it_generates_js_with_integrity()
+    {
+        $hash = hash('sha256', file_get_contents('./tests/files/app.js'), true);
+        $base64Hash = base64_encode($hash);
+
+        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", Sri::asset('app.js'));
+    }
+
+    /** @test */
+    public function it_generates_js_with_integrity_and_credentials()
+    {
+        $hash = hash('sha256', file_get_contents('./tests/files/app.js'), true);
+        $base64Hash = base64_encode($hash);
+
+        $asset_string = Sri::asset('app.js', true);
+
+        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
+        $this->assertStringContainsString("crossorigin='use-credentials'", $asset_string);
+    }
+
+    /** @test */
+    public function it_generates_js_with_integrity_and_attributes()
+    {
+        $hash = hash('sha256', file_get_contents('./tests/files/app.js'), true);
+        $base64Hash = base64_encode($hash);
+
+        $asset_string = Sri::asset('app.js', false, 'type="application/javascript" async');
+
+        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
+        $this->assertStringContainsString('type="application/javascript" async', $asset_string);
+    }
+
+    /** @test */
+    public function it_generates_js_with_integrity_credentials_and_attributes()
+    {
+        $hash = hash('sha256', file_get_contents('./tests/files/app.js'), true);
+        $base64Hash = base64_encode($hash);
+
+        $asset_string = Sri::asset('app.js', true, 'type="application/javascript" async');
+
+        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
+        $this->assertStringContainsString("crossorigin='use-credentials'", $asset_string);
+        $this->assertStringContainsString('type="application/javascript" async', $asset_string);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_file_extension_invalid()
+    {
+        $this->expectExceptionMessage('Invalid file');
+        Sri::asset('app.jpeg');
+    }
+}

--- a/tests/GenerateSriAssetTest.php
+++ b/tests/GenerateSriAssetTest.php
@@ -22,7 +22,7 @@ class GenerateSriAssetTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", Sri::asset('app.css'));
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', Sri::asset('app.css'));
     }
 
     /** @test */
@@ -33,8 +33,8 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.css', true);
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
-        $this->assertStringContainsString("crossorigin='use-credentials'", $asset_string);
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
+        $this->assertStringContainsString('crossorigin="use-credentials"', $asset_string);
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.css', false, 'rel="stylesheet"');
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
         $this->assertStringContainsString('rel="stylesheet"', $asset_string);
     }
 
@@ -57,8 +57,8 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.css', true, 'rel="stylesheet"');
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
-        $this->assertStringContainsString("crossorigin='use-credentials'", $asset_string);
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
+        $this->assertStringContainsString('crossorigin="use-credentials"', $asset_string);
         $this->assertStringContainsString('rel="stylesheet"', $asset_string);
     }
 
@@ -68,7 +68,7 @@ class GenerateSriAssetTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.js'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", Sri::asset('app.js'));
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', Sri::asset('app.js'));
     }
 
     /** @test */
@@ -79,8 +79,8 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.js', true);
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
-        $this->assertStringContainsString("crossorigin='use-credentials'", $asset_string);
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
+        $this->assertStringContainsString('crossorigin="use-credentials"', $asset_string);
     }
 
     /** @test */
@@ -91,7 +91,7 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.js', false, 'type="application/javascript" async');
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
         $this->assertStringContainsString('type="application/javascript" async', $asset_string);
     }
 
@@ -103,8 +103,8 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.js', true, 'type="application/javascript" async');
 
-        $this->assertStringContainsString("integrity='sha256-{$base64Hash}'", $asset_string);
-        $this->assertStringContainsString("crossorigin='use-credentials'", $asset_string);
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
+        $this->assertStringContainsString('crossorigin="use-credentials"', $asset_string);
         $this->assertStringContainsString('type="application/javascript" async', $asset_string);
     }
 

--- a/tests/GenerateSriMixTest.php
+++ b/tests/GenerateSriMixTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Elhebert\SubresourceIntegrity\Tests;
+
+use Elhebert\SubresourceIntegrity\SriFacade as Sri;
+
+class GenerateSriMixTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'subresource-integrity.mix_sri_path' => './tests/files/mix-sri.json',
+            'view.paths' => ['./tests/files'],
+        ]);
+
+        $this->app->instance('path.public', __DIR__ . '/files');
+    }
+
+    /** @test */
+    public function it_generates_css_with_integrity()
+    {
+        $this->assertStringContainsString('this-hash-is-valid', Sri::mix('css/app.css'));
+    }
+
+    /** @test */
+    public function it_generates_css_with_integrity_and_credentials()
+    {
+        $mix_string = Sri::mix('css/app.css', true);
+
+        $this->assertStringContainsString('this-hash-is-valid', $mix_string);
+        $this->assertStringContainsString("crossorigin='use-credentials'", $mix_string);
+    }
+
+    /** @test */
+    public function it_generates_css_with_integrity_and_attributes()
+    {
+        $mix_string = Sri::mix('css/app.css', false, 'rel="stylesheet"');
+
+        $this->assertStringContainsString('this-hash-is-valid', $mix_string);
+        $this->assertStringContainsString('rel="stylesheet"', $mix_string);
+    }
+
+    /** @test */
+    public function it_generates_css_with_integrity_credentials_and_attributes()
+    {
+        $mix_string = Sri::mix('css/app.css', true, 'rel="stylesheet"');
+
+        $this->assertStringContainsString('this-hash-is-valid', $mix_string);
+        $this->assertStringContainsString("crossorigin='use-credentials'", $mix_string);
+        $this->assertStringContainsString('rel="stylesheet"', $mix_string);
+    }
+
+    /** @test */
+    public function it_generates_js_with_integrity()
+    {
+        $this->assertStringContainsString('this-hash-is-valid', Sri::mix('js/app.js'));
+    }
+
+    /** @test */
+    public function it_generates_js_with_integrity_and_credentials()
+    {
+        $mix_string = Sri::mix('js/app.js', true);
+
+        $this->assertStringContainsString('this-hash-is-valid', $mix_string);
+        $this->assertStringContainsString("crossorigin='use-credentials'", $mix_string);
+    }
+
+    /** @test */
+    public function it_generates_js_with_integrity_and_attributes()
+    {
+        $mix_string = Sri::mix('js/app.js', false, 'type="application/javascript" async');
+
+        $this->assertStringContainsString('this-hash-is-valid', $mix_string);
+        $this->assertStringContainsString('type="application/javascript" async', $mix_string);
+    }
+
+    /** @test */
+    public function it_generates_js_with_integrity_credentials_and_attributes()
+    {
+        $mix_string = Sri::mix('js/app.js', true, 'type="application/javascript" async');
+
+        $this->assertStringContainsString('this-hash-is-valid', $mix_string);
+        $this->assertStringContainsString("crossorigin='use-credentials'", $mix_string);
+        $this->assertStringContainsString('type="application/javascript" async', $mix_string);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_file_extension_invalid()
+    {
+        $this->expectExceptionMessage('Invalid file');
+
+        Sri::mix('app.jpeg');
+    }
+}

--- a/tests/GenerateSriMixTest.php
+++ b/tests/GenerateSriMixTest.php
@@ -15,7 +15,7 @@ class GenerateSriMixTest extends TestCase
             'view.paths' => ['./tests/files'],
         ]);
 
-        $this->app->instance('path.public', __DIR__ . '/files');
+        $this->app->instance('path.public', __DIR__.'/files');
     }
 
     /** @test */

--- a/tests/GenerateSriMixTest.php
+++ b/tests/GenerateSriMixTest.php
@@ -30,7 +30,7 @@ class GenerateSriMixTest extends TestCase
         $mix_string = Sri::mix('css/app.css', true);
 
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
-        $this->assertStringContainsString("crossorigin='use-credentials'", $mix_string);
+        $this->assertStringContainsString('crossorigin="use-credentials"', $mix_string);
     }
 
     /** @test */
@@ -48,7 +48,7 @@ class GenerateSriMixTest extends TestCase
         $mix_string = Sri::mix('css/app.css', true, 'rel="stylesheet"');
 
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
-        $this->assertStringContainsString("crossorigin='use-credentials'", $mix_string);
+        $this->assertStringContainsString('crossorigin="use-credentials"', $mix_string);
         $this->assertStringContainsString('rel="stylesheet"', $mix_string);
     }
 
@@ -64,7 +64,7 @@ class GenerateSriMixTest extends TestCase
         $mix_string = Sri::mix('js/app.js', true);
 
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
-        $this->assertStringContainsString("crossorigin='use-credentials'", $mix_string);
+        $this->assertStringContainsString('crossorigin="use-credentials"', $mix_string);
     }
 
     /** @test */
@@ -82,7 +82,7 @@ class GenerateSriMixTest extends TestCase
         $mix_string = Sri::mix('js/app.js', true, 'type="application/javascript" async');
 
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
-        $this->assertStringContainsString("crossorigin='use-credentials'", $mix_string);
+        $this->assertStringContainsString('crossorigin="use-credentials"', $mix_string);
         $this->assertStringContainsString('type="application/javascript" async', $mix_string);
     }
 

--- a/tests/files/app.js
+++ b/tests/files/app.js
@@ -1,0 +1,1 @@
+alert('hello world!');

--- a/tests/files/assetSri-view.blade.php
+++ b/tests/files/assetSri-view.blade.php
@@ -1,0 +1,1 @@
+@assetSri($asset, $useCredentials, $attributes)

--- a/tests/files/mix-manifest.json
+++ b/tests/files/mix-manifest.json
@@ -1,0 +1,4 @@
+{
+    "/css/app.css" : "/css/app.css?id=some-random-string",
+    "/js/app.js" : "/js/app.js?id=some-random-string"
+}

--- a/tests/files/mix-sri.json
+++ b/tests/files/mix-sri.json
@@ -1,3 +1,4 @@
 {
-    "/css/app.css" : "this-hash-is-valid"
+    "/css/app.css" : "this-hash-is-valid",
+    "/js/app.js" : "this-hash-is-valid"
 }

--- a/tests/files/mixSri-view.blade.php
+++ b/tests/files/mixSri-view.blade.php
@@ -1,0 +1,1 @@
+@mixSri($asset, $useCredentials, $attributes)


### PR DESCRIPTION
This PR aims to improve the current blade directives available with the following notable changes:
- Can now pass multiple parameters to the `@mixSri` and `@assetSri` blade directives. 
    - Before, `@mixSri('app.css', true)` doesn't work since the directive because when extending the directive, it only allows 1 parameter. 
- A third parameter has been added to support other attributes for `script` and `link` tags attributes.
    - The new signature is `@assetSri(string $path, bool $useCredentials, string $attributes)`.
- The blade directive logic has been moved to the `Sri` class.
    - Did this to allow multiple variables to pass through in the blade directives.

This PR also adds tests for the blade directives which there wasn't any before.