### PR TITLE
hotfix : use appropriate tags for css and js

### DIFF
--- a/src/Sri.php
+++ b/src/Sri.php
@@ -87,9 +87,9 @@ class Sri
         $integrity = $this->html($path, $useCredentials);
 
         if (Str::endsWith($path, 'css')) {
-            return "<script src='{$href}' {$integrity} {$attributes}></script>";
-        } elseif (Str::endsWith($path, 'js')) {
             return "<link href='{$href}' rel='stylesheet' {$integrity} {$attributes}>";
+        } elseif (Str::endsWith($path, 'js')) {
+            return "<script src='{$href}' {$integrity} {$attributes}></script>";
         } else {
             throw new \Exception('Invalid file');
         }

--- a/tests/GenerateSriAssetTest.php
+++ b/tests/GenerateSriAssetTest.php
@@ -22,7 +22,10 @@ class GenerateSriAssetTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.css'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', Sri::asset('app.css'));
+        $asset_string = Sri::asset('app.css');
+
+        $this->assertStringContainsString('link', $asset_string);
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
     }
 
     /** @test */
@@ -35,6 +38,7 @@ class GenerateSriAssetTest extends TestCase
 
         $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
         $this->assertStringContainsString('crossorigin="use-credentials"', $asset_string);
+        $this->assertStringContainsString('link', $asset_string);
     }
 
     /** @test */
@@ -45,6 +49,7 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.css', false, 'rel="stylesheet"');
 
+        $this->assertStringContainsString('link', $asset_string);
         $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
         $this->assertStringContainsString('rel="stylesheet"', $asset_string);
     }
@@ -57,6 +62,7 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.css', true, 'rel="stylesheet"');
 
+        $this->assertStringContainsString('link', $asset_string);
         $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
         $this->assertStringContainsString('crossorigin="use-credentials"', $asset_string);
         $this->assertStringContainsString('rel="stylesheet"', $asset_string);
@@ -68,7 +74,10 @@ class GenerateSriAssetTest extends TestCase
         $hash = hash('sha256', file_get_contents('./tests/files/app.js'), true);
         $base64Hash = base64_encode($hash);
 
-        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', Sri::asset('app.js'));
+        $asset_string = Sri::asset('app.js');
+
+        $this->assertStringContainsString('script', $asset_string);
+        $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
     }
 
     /** @test */
@@ -79,6 +88,7 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.js', true);
 
+        $this->assertStringContainsString('script', $asset_string);
         $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
         $this->assertStringContainsString('crossorigin="use-credentials"', $asset_string);
     }
@@ -91,6 +101,7 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.js', false, 'type="application/javascript" async');
 
+        $this->assertStringContainsString('script', $asset_string);
         $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
         $this->assertStringContainsString('type="application/javascript" async', $asset_string);
     }
@@ -103,6 +114,7 @@ class GenerateSriAssetTest extends TestCase
 
         $asset_string = Sri::asset('app.js', true, 'type="application/javascript" async');
 
+        $this->assertStringContainsString('script', $asset_string);
         $this->assertStringContainsString('integrity="sha256-'.$base64Hash.'"', $asset_string);
         $this->assertStringContainsString('crossorigin="use-credentials"', $asset_string);
         $this->assertStringContainsString('type="application/javascript" async', $asset_string);

--- a/tests/GenerateSriMixTest.php
+++ b/tests/GenerateSriMixTest.php
@@ -21,7 +21,10 @@ class GenerateSriMixTest extends TestCase
     /** @test */
     public function it_generates_css_with_integrity()
     {
-        $this->assertStringContainsString('this-hash-is-valid', Sri::mix('css/app.css'));
+        $mix_string = Sri::mix('css/app.css');
+
+        $this->assertStringContainsString('link', $mix_string);
+        $this->assertStringContainsString('this-hash-is-valid', $mix_string);
     }
 
     /** @test */
@@ -29,6 +32,7 @@ class GenerateSriMixTest extends TestCase
     {
         $mix_string = Sri::mix('css/app.css', true);
 
+        $this->assertStringContainsString('link', $mix_string);
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
         $this->assertStringContainsString('crossorigin="use-credentials"', $mix_string);
     }
@@ -38,6 +42,7 @@ class GenerateSriMixTest extends TestCase
     {
         $mix_string = Sri::mix('css/app.css', false, 'rel="stylesheet"');
 
+        $this->assertStringContainsString('link', $mix_string);
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
         $this->assertStringContainsString('rel="stylesheet"', $mix_string);
     }
@@ -47,6 +52,7 @@ class GenerateSriMixTest extends TestCase
     {
         $mix_string = Sri::mix('css/app.css', true, 'rel="stylesheet"');
 
+        $this->assertStringContainsString('link', $mix_string);
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
         $this->assertStringContainsString('crossorigin="use-credentials"', $mix_string);
         $this->assertStringContainsString('rel="stylesheet"', $mix_string);
@@ -55,7 +61,10 @@ class GenerateSriMixTest extends TestCase
     /** @test */
     public function it_generates_js_with_integrity()
     {
-        $this->assertStringContainsString('this-hash-is-valid', Sri::mix('js/app.js'));
+        $mix_string = Sri::mix('js/app.js');
+
+        $this->assertStringContainsString('script', $mix_string);
+        $this->assertStringContainsString('this-hash-is-valid', $mix_string);
     }
 
     /** @test */
@@ -63,6 +72,7 @@ class GenerateSriMixTest extends TestCase
     {
         $mix_string = Sri::mix('js/app.js', true);
 
+        $this->assertStringContainsString('script', $mix_string);
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
         $this->assertStringContainsString('crossorigin="use-credentials"', $mix_string);
     }
@@ -72,6 +82,7 @@ class GenerateSriMixTest extends TestCase
     {
         $mix_string = Sri::mix('js/app.js', false, 'type="application/javascript" async');
 
+        $this->assertStringContainsString('script', $mix_string);
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
         $this->assertStringContainsString('type="application/javascript" async', $mix_string);
     }
@@ -81,6 +92,7 @@ class GenerateSriMixTest extends TestCase
     {
         $mix_string = Sri::mix('js/app.js', true, 'type="application/javascript" async');
 
+        $this->assertStringContainsString('script', $mix_string);
         $this->assertStringContainsString('this-hash-is-valid', $mix_string);
         $this->assertStringContainsString('crossorigin="use-credentials"', $mix_string);
         $this->assertStringContainsString('type="application/javascript" async', $mix_string);


### PR DESCRIPTION
URGENT!

https://github.com/Elhebert/laravel-sri/blob/1e5e121e48a6064ba25009349b152ed0354bc518/src/Sri.php#L89-L95

I didn't notice that I used `script` tag for `css` and `link` tag for `js`.

This PR aims to resolve this problem

P.S. I'm really sorry :cry: