### PR TITLE
[v3] Disable computing hash for assets from third party providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ php artisan vendor:publish --provider="Elhebert\SubresourceIntegrity\SriServiceP
 
 ### Content of the configuration
 
-| key          | default value                 | possible values                                |
-| ------------ | ----------------------------- | ---------------------------------------------- |
-| base_path    | `base_path('/public')`        |                                                |
-| algorithm    | sha256                        | sha256, sha384 and sha512                      |
-| hashes       | `[]`                          | (see "[How to get a hash](#how-to-get-a-hash)) |
-| mix_sri_path | `public_path('mix-sri.json')` | (see "[How to get a hash](#how-to-get-a-hash)) |
-| enabled      | `true`                        |                                                |
+| key                                  | default value                 | possible values                                |
+| ------------------------------------ | ----------------------------- | ---------------------------------------------- |
+| base_path                            | `base_path('/public')`        |                                                |
+| algorithm                            | sha256                        | sha256, sha384 and sha512                      |
+| hashes                               | `[]`                          | (see "[How to get a hash](#how-to-get-a-hash)) |
+| mix_sri_path                         | `public_path('mix-sri.json')` | (see "[How to get a hash](#how-to-get-a-hash)) |
+| enabled                              | `true`                        |                                                |
+| dangerously_allow_third_party_assets | `false`                       |                                                |
 
 ## Usage
 
@@ -59,15 +60,12 @@ To only get a hash, use `Sri::hash`:
 
 To generate the HTML for the `integrity` and the `crossorigin` attributes, use `Sri::html`. It accepts two parameters:
 
-- first one is the path;
-- second one (default is `false`) tells if you want to pass the credentials when fetching the resource.
+-   first one is the path;
+-   second one (default is `false`) tells if you want to pass the credentials when fetching the resource.
 
 ```html
-<link
-    href="{{ asset('css/app.css') }}"
-    rel="stylesheet"
-    {{ Sri::html('css/app.css') }}
->
+<link href="{{ asset('css/app.css') }}" rel="stylesheet" {{
+Sri::html('css/app.css') }} >
 ```
 
 ### Blade directive

--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ To generate the HTML for the `integrity` and the `crossorigin` attributes, use `
 -   second one (default is `false`) tells if you want to pass the credentials when fetching the resource.
 
 ```html
-<link href="{{ asset('css/app.css') }}" rel="stylesheet" {{
-Sri::html('css/app.css') }} >
+<link
+    href="{{ asset('css/app.css') }}"
+    rel="stylesheet"
+    {{ Sri::html('css/app.css') }}
+/>
 ```
 
 ### Blade directive

--- a/config/subresource-integrity.php
+++ b/config/subresource-integrity.php
@@ -71,10 +71,9 @@ return [
     | Dangerously Allow Third Party Assets
     |--------------------------------------------------------------------------
     |
-    | This option determines if it should generate a hash for third party
-    | assets. We highly recommend you to set this to false and compute the hash
-    | for this assets manually then add them to the "hashes" config found in
-    | this file.
+    | This option determines if it should generate a hash for the third party assets.
+    | We highly recommend you to set this to false. You should compute the hash
+    | for theses assets manually and add them to the "hashes" config key.
     |
     */
 

--- a/config/subresource-integrity.php
+++ b/config/subresource-integrity.php
@@ -71,7 +71,7 @@ return [
     | Dangerously Allow Third Party Assets
     |--------------------------------------------------------------------------
     |
-    | This option determines if it should generate a hash for third party 
+    | This option determines if it should generate a hash for third party
     | assets. We highly recommend you to set this to false and compute the hash
     | for this assets manually then add them to the "hashes" config found in
     | this file.

--- a/config/subresource-integrity.php
+++ b/config/subresource-integrity.php
@@ -66,4 +66,18 @@ return [
 
     'enabled' => env('SRI_ENABLED', true),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Dangerously Allow Third Party Assets
+    |--------------------------------------------------------------------------
+    |
+    | This option determines if it should generate a hash for third party 
+    | assets. We highly recommend you to set this to false and compute the hash
+    | for this assets manually then add them to the "hashes" config found in
+    | this file.
+    |
+    */
+
+    'dangerously_allow_third_party_assets' => false,
+
 ];

--- a/src/Sri.php
+++ b/src/Sri.php
@@ -45,7 +45,7 @@ class Sri
             return config('subresource-integrity.hashes')[$path];
         }
         
-        if(Str::startsWith($path, ['http', 'https', '//']) && ! config('subresource-integrity.dangerously_allow_third_party_assets')){
+        if (Str::startsWith($path, ['http', 'https', '//']) && ! config('subresource-integrity.dangerously_allow_third_party_assets')) {
             return '';
         }
 

--- a/src/Sri.php
+++ b/src/Sri.php
@@ -44,7 +44,7 @@ class Sri
         if ($this->existsInConfigFile($path)) {
             return config('subresource-integrity.hashes')[$path];
         }
-        
+
         if (Str::startsWith($path, ['http', 'https', '//']) && ! config('subresource-integrity.dangerously_allow_third_party_assets')) {
             return '';
         }

--- a/src/Sri.php
+++ b/src/Sri.php
@@ -44,6 +44,10 @@ class Sri
         if ($this->existsInConfigFile($path)) {
             return config('subresource-integrity.hashes')[$path];
         }
+        
+        if(Str::startsWith($path, ['http', 'https', '//']) && ! config('subresource-integrity.dangerously_allow_third_party_assets')){
+            return '';
+        }
 
         if ($this->mixFileExists()) {
             $json = json_decode(file_get_contents($this->jsonFilePath()));

--- a/tests/GenerateSriHashTest.php
+++ b/tests/GenerateSriHashTest.php
@@ -70,4 +70,23 @@ class GenerateSriHashTest extends TestCase
 
         $this->assertEquals('', Sri::hash('files/app.css'));
     }
+
+    /** @test */
+    public function it_returns_an_empty_string_when_hashing_third_party_assets()
+    {
+        $this->assertEquals('', Sri::hash('https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js'));
+    }
+
+    /** @test */
+    public function it_can_hash_third_party_assets_when_enabled()
+    {
+        config([
+            'subresource-integrity.dangerously_allow_third_party_assets' => true,
+        ]);
+
+        $hash = hash('sha256', file_get_contents('https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js'), true);
+        $base64Hash = base64_encode($hash);
+
+        $this->assertEquals("sha256-{$base64Hash}", Sri::hash('https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js'));
+    }
 }


### PR DESCRIPTION
This PR aims to address the security concern discussed in #57 

Added a `dangerously_allow_third_party_assets` option in the config file.

This option determines if it should generate a hash for third party assets. We highly recommend you to set this to false and compute the hash for this assets manually then add them to the "hashes" config found in this file.