### PR TITLE
fix: add closing tag to "script" tag

### DIFF
--- a/src/Components/Script.php
+++ b/src/Components/Script.php
@@ -36,7 +36,7 @@ class Script extends Component
     public function render(): string
     {
         return <<<'blade'
-        <script src="{{ $path() }}" integrity="{{ $integrity() }}" crossorigin="{{ $crossorigin }}" {{ $attributes }} />
+        <script src="{{ $path() }}" integrity="{{ $integrity() }}" crossorigin="{{ $crossorigin }}" {{ $attributes }}></script>
         blade;
     }
 }

--- a/tests/Components/ScriptTest.php
+++ b/tests/Components/ScriptTest.php
@@ -24,7 +24,7 @@ class ScriptTest extends TestCase
 
         $view = View::file(dirname(__DIR__).'/files/script.blade.php', ['mix' => false, 'crossOrigin' => 'anonymous'])->render();
         $expected = <<<'HTML'
-        <script src="http://localhost/js/app.js" integrity="this-hash-is-valid" crossorigin="anonymous"  />
+        <script src="http://localhost/js/app.js" integrity="this-hash-is-valid" crossorigin="anonymous" ></script>
         HTML;
 
         $this->assertStringContainsString(
@@ -44,7 +44,7 @@ class ScriptTest extends TestCase
 
         $view = View::file(dirname(__DIR__).'/files/script.blade.php', ['mix' => true, 'crossOrigin' => 'anonymous'])->render();
         $expected = <<<'HTML'
-        <script src="/js/app.js?id=some-random-string" integrity="this-hash-is-valid" crossorigin="anonymous"  />
+        <script src="/js/app.js?id=some-random-string" integrity="this-hash-is-valid" crossorigin="anonymous" ></script>
         HTML;
 
         $this->assertStringContainsString(
@@ -64,7 +64,7 @@ class ScriptTest extends TestCase
 
         $view = View::file(dirname(__DIR__).'/files/script.blade.php', ['mix' => false, 'crossOrigin' => 'test'])->render();
         $expected = <<<'HTML'
-        <script src="http://localhost/js/app.js" integrity="this-hash-is-valid" crossorigin="test"  />
+        <script src="http://localhost/js/app.js" integrity="this-hash-is-valid" crossorigin="test" ></script>
         HTML;
 
         $this->assertStringContainsString(


### PR DESCRIPTION
I had a weird issue where in my production app, the JavaScript wasn't working. Spent ages debugging and apparently `<script>` elements should always have a closing tag, rather than auto-closing. And applying this change seemed to resolve the issue.

I'm not sure if this is just a regression with Firefox developer edition, although it also seemed to fail in Chrome (I'm running on macOS Big Sur), but I'd be interested to know if anyone else experienced this issue.

For reference, I am using HTML 5 DocType (`<!DOCTYPE html>`), so self-closing tags should in theory be fine. Although according to MDN, both `<script>` and `</script>` should always be included. It looks like this is how it was done in v2.x https://github.com/Elhebert/laravel-sri/blob/bc7d65c56a60b4ffbcce9aa7dab1466f3dc6f017/src/Sri.php#L96